### PR TITLE
Support optional tokens in rules

### DIFF
--- a/lib/antlr4-native/context.rb
+++ b/lib/antlr4-native/context.rb
@@ -148,6 +148,11 @@ module Antlr4Native
               }
 
               auto token = ((#{parser_ns}::#{name}*)orig) -> #{token_mtd.name}(#{params});
+
+              if (token == nullptr) {
+                return Qnil;
+              }
+
               TerminalNodeProxy proxy(token);
               return to_ruby(proxy);
             }


### PR DESCRIPTION
Return null when an optional token is missing in the input.