### PR TITLE
Change_gem_name

### DIFF
--- a/lib/antlr4-native/generator.rb
+++ b/lib/antlr4-native/generator.rb
@@ -25,7 +25,7 @@ module Antlr4Native
     end
 
     def gem_name
-      @gem_name ||= dasherize(parser_ns)
+      @gem_name ||= underscore(parser_ns)
     end
 
     def antlr_ns
@@ -316,7 +316,7 @@ module Antlr4Native
       <<~END
         extern "C"
         void Init_#{ext_name}() {
-          Module rb_m#{parser_ns} = define_module("#{parser_ns}");
+          Module rb_m#{parser_ns} = define_module("#{capitalize(parser_ns)}");
 
           rb_cToken = define_class_under<Token>(rb_m#{parser_ns}, "Token")
             .define_method("text", &Token::getText)

--- a/lib/antlr4-native/version.rb
+++ b/lib/antlr4-native/version.rb
@@ -1,3 +1,3 @@
 module Antlr4Native
-  VERSION = '2.1.1'
+  VERSION = '2.1.0'
 end

--- a/lib/antlr4-native/version.rb
+++ b/lib/antlr4-native/version.rb
@@ -1,3 +1,3 @@
 module Antlr4Native
-  VERSION = '2.0.1'
+  VERSION = '2.1.1'
 end


### PR DESCRIPTION
The gem naming guidelins state that for a gem called UrlParser - the gem should be called url_parser and for gem called url-parser the class shoud be Url::Parser under dir url
https://guides.rubygems.org/name-your-gem/ this changes to underscore instead of dash for gem name